### PR TITLE
Support formulae when splitting gadgetfile lines

### DIFF
--- a/R/gadgetfile.R
+++ b/R/gadgetfile.R
@@ -498,6 +498,7 @@ read.gadget.file <- function(path, file_name, file_type = "generic", fileEncodin
                 quote = "",
                 sep = "\t",
                 col.names = header,
+                comment.char = "",
                 fileEncoding = 'utf8')
             attr(cur_comp, 'preamble') <- comp_preamble
             cur_preamble <- list()

--- a/tests/test-gadgetfile.R
+++ b/tests/test-gadgetfile.R
@@ -294,13 +294,13 @@ ok_group("Can read gadget files", {
         ver_string,
         "; -- data --",
         "; col\tcolm\tcolt\tcoal",
-        "3    5\t(9 10 (11 12)\t) 13",
+        "3    5\t(9 10 (#potato 12)\t) 13",
         file_type = "generic")
     ok(cmp(unattr(gf), list(
         data.frame(
             col = as.integer(3),
             colm = as.integer(5),
-            colt = "(9 10 (11 12) )",
+            colt = "(9 10 (#potato 12) )",
             coal = as.integer(13)))), "Data with mangled spacing & formulae")
 
     # Blank preamble lines get preserved


### PR DESCRIPTION
This defines split_gadgetfile_line, and then uses it both when reading tables and key/value lines. This still doesn't auto-interpret formulae, but you can almost smell it now :) 

Note the output for fleetfiles has changed, but I think for the better. Also any custom spacing (e.g. use of 4 spaces instead of tabs) isn't preserved.
