### PR TITLE
get.gadget.growth() update

### DIFF
--- a/R/gadgetFileIO.R
+++ b/R/gadgetFileIO.R
@@ -1857,8 +1857,17 @@ get.gadget.growth <- function(stocks,params,dt=0.25,age.based=FALSE){
     lt <- getLengthGroups(x)
     if(age.based){
       age <- x@minage:x@maxage
-      data.frame(stock=x@stockname,age=age,
-                 length=suit.par[1]*(1-exp(-suit.par[2]*age)))
+	  ## added by PNF to add recruitment mean length to vonB growth function - Sept.28, 2016
+	  try(renewal.mn.formula <- unlist(strsplit(x@initialdata$mean[1], ' ')), silent=T)
+	  if (exists('renewal.mn.formula') & 
+			all(renewal.mn.formula[c(1,2,4,5,6,7,8)]==c('(','*','(','-','1','(','exp'))) {
+	      rec.switch <- renewal.mn.formula[31]
+		  rec.switch <- gsub('#', '', rec.switch)
+		  rec.length <- params[grep(rec.switch, params$switch), ]$value
+		  t0 <- log((-1)*((rec.length / suit.par[1])-1)) / (-suit.par[2])
+	  } else {t0 <- 0}
+	  data.frame(stock=x@stockname,age=age,
+                 length=suit.par[1]*(1-exp(-suit.par[2]*(age+t0))))
     } else {
       melt(growthprob(lt,suit.par[5],suit.par[1],suit.par[2],dt,
                       suit.par[6],max(diff(lt))),


### PR DESCRIPTION
Updated get.gadget.growth() to include a t0 component. This is done by testing if there is a formula for mean recruitment length, finding the switch for rec.length, and using that switch value to determine t0. If no switch is discovered (i.e. mean rec length is not estimate), then t0 = 0.
