### PR TITLE
Added printing options to make.gadget.printfile

### DIFF
--- a/R/gadgetFileIO.R
+++ b/R/gadgetFileIO.R
@@ -487,7 +487,9 @@ write.gadget.parameters <- function(params,file='params.out',columns=TRUE){
 ##' @export
 make.gadget.printfile <- function(main='main',output='out',
                                   aggfiles='print.aggfiles',
-                                  file='printfile'){
+                                  file='printfile',
+								  printatstart = 1,
+								  steps = 1){
     
     main <- read.gadget.main(main)
     lik <- read.gadget.likelihood(main$likelihoodfiles)
@@ -515,8 +517,8 @@ make.gadget.printfile <- function(main='main',output='out',
               'type\tstockstdprinter',
               'stockname\t%1$s',
               sprintf('printfile\t%s/%%1$s.std',output),
-              'printatstart 1',
-              'yearsandsteps\t all 1',sep='\n')
+              sprintf('printatstart %s', printatstart),
+              sprintf('yearsandsteps\tall\t%s', steps),sep='\n')
     
     stock.full <-
         paste('[component]',
@@ -526,8 +528,8 @@ make.gadget.printfile <- function(main='main',output='out',
               sprintf('ageaggfile\t%s/%%1$s.allages.agg',aggfiles),
               sprintf('lenaggfile\t%s/%%1$s.len.agg',aggfiles),
               sprintf('printfile\t%s/%%1$s.full',output),
-              'printatstart 1',
-              'yearsandsteps\t all 1',sep='\n')
+			  sprintf('printatstart\t%s', printatstart),
+              sprintf('yearsandsteps\tall\t%s', steps),sep='\n')
     
     predator <-
         paste('[component]',

--- a/R/gadgetfit.R
+++ b/R/gadgetfit.R
@@ -15,7 +15,8 @@ gadget.fit <- function(wgts = 'WGTS', main.file = NULL,
                        fleet.predict = data.frame(fleet='comm',ratio=1),
                        mat.par=NULL, params.file=NULL,
                        f.age.range=NULL, fit.folder = 'FIT',
-                       compile.fleet.info = TRUE){
+                       compile.fleet.info = TRUE,
+					   printfile.printatstart = 1, printfile.steps = 1){
   
   if(is.null(main.file)) {
     if(is.null(wgts)){
@@ -47,7 +48,9 @@ gadget.fit <- function(wgts = 'WGTS', main.file = NULL,
   make.gadget.printfile(main = main.file,
                         file = sprintf('%s/printfile.fit',wgts),
                         out = sprintf('%s/out.fit',wgts),
-                        aggfiles = sprintf('%s/print.aggfiles',wgts))
+                        aggfiles = sprintf('%s/print.aggfiles',wgts),
+						printatstart = printfile.printatstart,
+						steps = printfile.steps)
   
   main$printfiles <- sprintf('%s/printfile.fit',wgts)
   write.gadget.main(main,file = sprintf('%s/main.print',wgts))


### PR DESCRIPTION
I added 2 arguments to `make.gadget.printfile` to allow for a bit more flexibility in the printing options called by `gadget.fit`. There is a printatstart and a step argument in `make.gadget.printfile`, which allow users to specify these respective printing options in the stockstdprinter and stockfullprinter. Arguments were defaulted to what was previously printed out. I also updated `gadget.fit` arguments to reflect changes.